### PR TITLE
Various changes

### DIFF
--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -118,7 +118,9 @@ router.get("/current_user", async (req, res) => {
       },
     });
   } else {
-    return res.status(401).json({ user: null });
+    return res.status(401).json({ user: {
+      id: -1
+    }});
   }
 });
 

--- a/backend/routes/user.js
+++ b/backend/routes/user.js
@@ -65,6 +65,28 @@ router.get("/my_restaurant", autheticateUser, async (req, res)=>{
     }
 });
 
+router.get("/restaurants/:userId", async (req, res)=>{
+    const userid = parseInt(req.params.userId, 10);
+    try{
+        const user_restaurants = await Restaurant.findAll({
+            where: {
+                UserId: userid
+            }
+        });
+
+        if (user_restaurants.length === 0){
+            return res.status(404).json({message: "No restaurant found"});
+        }
+        else{
+            return res.status(201).json(user_restaurants);
+        }
+
+    }catch(error){
+        const errorMessage = error.message;
+        return res.status(500).json({message: "An error occured when fetching for restaurants", error: errorMessage})
+    }
+});
+
 router.get("/get_user/:userId", async(req, res)=>{
     console.log("Attempting to fetch user:", req.params.userId);
     const userId = parseInt(req.params.userId,10);
@@ -126,7 +148,8 @@ try {
     await user.update({
         username: req.body.username ? req.body.username : user.username,
         email: req.body.email ? req.body.email : user.email,
-        profileImage: req.body.profileImage ? req.body.profileImage : user.profileImage
+        profileImage: req.body.profileImage ? req.body.profileImage : user.profileImage,
+        hasRestaurant: req.body.hasRestaurant ? req.body.hasRestaurant : user.hasRestaurant
     });
 
     return res.status(200).json({ message: "User information updated successfully" });

--- a/frontend/social-bites/src/NavBar/NavBar.jsx
+++ b/frontend/social-bites/src/NavBar/NavBar.jsx
@@ -128,6 +128,9 @@ export default function NavBar() {
                     <span className="block truncate text-sm font-medium">
                       User@user.com
                     </span>
+                    <div className="dropdown-list">
+                      Profile
+                    </div>
                   </div>
                 )}
               </Dropdown.Header>

--- a/frontend/social-bites/src/RestaurantSettings/RestaurantSettings.css
+++ b/frontend/social-bites/src/RestaurantSettings/RestaurantSettings.css
@@ -1,6 +1,8 @@
 .body {
   /* background-image: linear-gradient(79deg, #a71109, #eb694e 48%, #f3bfbb); */
   background-color: rgb(252, 231, 231);
+  min-width: 100vw;
+  min-height: 100vh;
   overflow-x: hidden;
 }
 

--- a/frontend/social-bites/src/UserPage/UserPage.jsx
+++ b/frontend/social-bites/src/UserPage/UserPage.jsx
@@ -1,6 +1,7 @@
-import { Link } from "react-router-dom";
+import { Link, Outlet } from "react-router-dom";
 import "./UserPageStyle.css";
 import { FaCameraRetro, FaStar, FaPlus } from "react-icons/fa";
+import { GiFoodTruck } from "react-icons/gi";
 import { PiForkKnifeBold } from "react-icons/pi";
 import UserReviews from "./UserReviews";
 import { useParams } from "react-router-dom";
@@ -8,8 +9,13 @@ import { useEffect, useState } from "react";
 
 export default function UserPage() {
   const [userInfo, setUserInfo] = useState(null);
+  const [tempImageUrl, setTempImageUrl] = useState("");
+  const [isCorrectUser, setIsCorrectUser] = useState(false);
+  const [current, setCurrentUser] = useState([]);
+  const [restaurants, setRestaurants] = useState([]);
+  const [loadingData, setLoadingData] = useState(true);
+  
   let { id } = useParams();
-  let person;
   async function getUser(userId) {
     try {
       const response = await fetch(`/api/user/get_user/${userId}`);
@@ -21,24 +27,128 @@ export default function UserPage() {
     }
   }
 
+  async function getLoggedUser() {
+    const response = await fetch(`/api/auth/current_user`);
+    const user = await response.json();
+    setCurrentUser(user);
+    return user;
+  }
+
+  async function getRestaurants(id) {
+    const response = await fetch(`/api/user/restaurants/${id}`);
+    const myRestaurants = await response.json();
+    setRestaurants(myRestaurants);
+    console.log("API Response:", myRestaurants);
+    return myRestaurants;
+  }
+
+  async function handleImageChange() {
+    const newImageUrl = prompt("Enter the new image URL. This will be your new profile picture!");
+    if (newImageUrl) {
+        setTempImageUrl(newImageUrl);
+
+        const payload = {
+            profileImage: newImageUrl
+        };
+
+        try {
+            const response = await fetch(`/api/user/editUser`, {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload)
+            });
+
+            if (!response.ok) {
+                throw new Error(`Server responded with ${response.status}`);
+            }
+
+            // Update local userInfo state with new image URL
+            setUserInfo(prevUserInfo => ({
+                ...prevUserInfo,
+                profileImage: newImageUrl
+            }));
+
+        } catch (error) {
+            console.error("Error updating user image:", error);
+        }
+    } else {
+      return null;
+    }
+}
+
+async function hasRestaurantEdit(bool) {
+    
+        const payload = {
+            hasRestaurant: bool
+        };
+
+        try {
+            const response = await fetch(`/api/user/editUser`, {
+                method: "PATCH",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload)
+            });
+
+            if (!response.ok) {
+                throw new Error(`Server responded with ${response.status}`);
+            }
+
+            // Update local userInfo state with new image URL
+            setRestaurants(prevUserInfo => ({
+                ...prevUserInfo,
+                hasRestaurant: bool
+            }));
+
+        } catch (error) {
+            console.error("Error updating hasRestaurant bool:", error);
+        }
+  }
+
   useEffect(() => {
     async function fetchData() {
+      setLoadingData(true); // Start loading
+  
       const user = await getUser(id);
+      const currentuse = await getLoggedUser();
+  
+      console.log(currentuse);
       setUserInfo(user);
-      console.log(userInfo);
+      setCurrentUser(currentuse);
+  
+      const correctUser = user.UserId === currentuse.user.id;
+      setIsCorrectUser(correctUser);
+  
+        const myRes = await getRestaurants(id);
+        setRestaurants(myRes);
+        console.log(myRes);
+  
+        if (!Array.isArray(myRes) && !currentuse.user.hasRestaurant) {
+          await hasRestaurantEdit(true);
+        }
+  
+      setLoadingData(false); // Finish loading after all data is fetched
     }
+  
     fetchData();
   }, []);
+  
 
   return (
     <>
-      {userInfo ? (
+      {userInfo && !loadingData ? (
         <div className="user-page flex flex-col">
           <div className="user-heading flex flex-row"></div>
 
           <div className="user-body">
             <div className="profile-left">
               <img className="user-image" src={userInfo.profileImage} />
+              { isCorrectUser ? <button className="change-image-button" onClick={handleImageChange}>
+              Change Image
+              </button> : null }
               <div className="bio-box">
                 <h2 className="user-name">{userInfo.username}</h2>
                 <p className="bio">
@@ -50,6 +160,12 @@ export default function UserPage() {
               </div>
 
               <ul className="user-options flex flex-col items-start w-full p-5 gap-4">
+              <li>
+                  <Link to={`/user/${id}`} className="user-menu-item flex flex-row">
+                    <FaCameraRetro />
+                    Home
+                  </Link>
+                </li>
                 <li>
                   <Link to="" className="user-menu-item flex flex-row">
                     <FaCameraRetro />
@@ -68,7 +184,13 @@ export default function UserPage() {
                     Following
                   </Link>
                 </li>
-                <li>
+                { userInfo.hasRestaurant ?  <li>
+                  <Link to="restaurants" className="user-menu-item flex flex-row">
+                    <GiFoodTruck />
+                    Owned Restaurants
+                  </Link>
+                </li> : null}
+                { isCorrectUser ? <li>
                   <Link
                     to="/addrestaurant"
                     className="user-menu-item flex flex-row"
@@ -76,7 +198,7 @@ export default function UserPage() {
                     <FaPlus />
                     Add Restaurant
                   </Link>
-                </li>
+                </li> : null }
               </ul>
 
               <div className="break" />
@@ -124,7 +246,7 @@ export default function UserPage() {
                     ullamco laboris nisi ut aliquip ex ea commodo consequat.
                   </p>
                 </div>
-                <UserReviews />
+                <Outlet context={[isCorrectUser, restaurants]}/>
               </div>
             </div>
             <div className="containing">

--- a/frontend/social-bites/src/UserPage/UserPageStyle.css
+++ b/frontend/social-bites/src/UserPage/UserPageStyle.css
@@ -30,7 +30,9 @@
     align-items: center;
     min-height: 100%;
     border-radius: 1em 0 0 0;
+    position: relative;
 }
+
 
 .user-image {
     background-color: gray;
@@ -44,7 +46,6 @@
 
 .user-image, .user-image-small {
     border-radius: 50%;
-    
 }
 
 
@@ -158,4 +159,43 @@
 
 ul li h2 {
     font-size: 1.3em;
+}
+
+.change-image-button {
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0);
+    color: rgba(0, 0, 0, 0);
+    border: none;
+    cursor: pointer;
+    transition: 0.3s;
+    transform: translateX(-50%);
+    font-size: 0.8em;
+    position: absolute;
+    z-index: 10;  
+    bottom: 100%;  
+    left: 50%;
+    transform: translate(-50%, 50%);  
+    width: 6em;
+    height: 6em;
+    border-radius: 50%;
+    padding: 1em;
+    
+    /* ... other existing styles ... */
+
+
+   
+}
+
+.change-image-button:hover {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    
+}
+
+.trash:hover {
+    cursor: pointer;
+}
+
+.user-image-small-r {
+    border-radius: .3em;
 }

--- a/frontend/social-bites/src/UserPage/UserRestaurants.jsx
+++ b/frontend/social-bites/src/UserPage/UserRestaurants.jsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { useOutletContext } from "react-router-dom/dist/umd/react-router-dom.development";
+
+
+export default function UserRestaurants() {
+    const [isCorrectUser, restaurants] = useOutletContext();
+    
+    function renderRestaurants() {
+        return restaurants.map((item, index) => (
+            <div className="review-box" key={item.id}>
+                <div className="review-header flex flex-row justify-between">
+                    <div className="res-detail-box flex flex-row gap-4">
+                        <img className="user-image-small-r w-14 h-14" src={item.profileImage}></img>
+                        <div className="res-details">
+                            <p>{item.restaurantName}</p>
+                            <p>{item.address}</p>
+                        </div>
+                    </div>
+                    <div className="rate flex flex-row">
+                    </div>
+                </div>
+                <p className="review-body">
+                    Restaurant description placeholder
+                </p>
+            </div>
+        ));
+    }
+
+    return <>{ renderRestaurants() }</>;
+}

--- a/frontend/social-bites/src/main.jsx
+++ b/frontend/social-bites/src/main.jsx
@@ -79,6 +79,8 @@ import Tags from "./UserSettings/Tags/Tags";
 
 // modal window for post
 import PostModal from "./Component/ModalWindow/ModalWindow";
+import UserReviews from "./UserPage/UserReviews";
+import UserRestaurants from "./UserPage/UserRestaurants";
 
 const router = createBrowserRouter([
   {
@@ -168,6 +170,16 @@ const router = createBrowserRouter([
         path: "/user/:id",
         // loader: userReviewsLoader,
         element: <UserPage />,
+        children: [
+          {
+            path: "/user/:id",
+            element: <UserReviews />
+          },
+          {
+            path: "/user/:id/restaurants",
+            element: <UserRestaurants />
+          }
+        ]
       },
       {
         path: "/addrestaurant",

--- a/frontend/social-bites/src/main.jsx
+++ b/frontend/social-bites/src/main.jsx
@@ -83,12 +83,10 @@ import PostModal from "./Component/ModalWindow/ModalWindow";
 const router = createBrowserRouter([
   {
     path: "/",
-    loader: load,
     element: <NavBar />,
     children: [
       {
         path: "/",
-        loader: load,
         element: <Home />,
         children: [
           {


### PR DESCRIPTION
**In this pull request:**

- Users can now delete reviews they've left on through their own user page. The delete icon is only shown to the logged in user

- People can see all the restaurants a user owns by going to their profile and clicking on "Owned Restaurants" (required a new endpoint to fetch all restaurants a user has, without going through authentication, at /api/user/restaurants/:id)

- Changed the return value of /api/auth/current_user from { user: { null } } to { user: { id: -1} } for comparison purposes

- Fixed a bug where restaurants from the new endpoint would only show to the logged in user who actually owned them

- User images can now take in a URL input and change according to the image URL the user puts in. Only available to the logged in user on their own user page, when they hover over their icon. Required a change too a user patch endpoint to include patching the profileImage column.

- The background on the restaurant/settings pages now stretches all the way down on all screen sizes (previously left a white blank section on the bottom of my monitor, but looked fine on smaller screens)
 
 **Still working on these features for the next pull request:**
 
 - Sitewide loading page (requires use of context)
 
 - Adding a Profile button to the dropdown menu in order to allow users easy access to their profiles
 
 - Making it impossible to leave a review if not logged in
 
- Code cleanup in certain areas

- Style changes